### PR TITLE
fixed write FORCED attribute unquoted. E.g. FORCED=NO

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -136,9 +136,8 @@ func (p *MasterPlaylist) Encode() *bytes.Buffer {
 					p.buf.WriteRune('"')
 				}
 				if alt.Forced != "" {
-					p.buf.WriteString(",FORCED=\"")
+					p.buf.WriteString(",FORCED=")
 					p.buf.WriteString(alt.Forced)
-					p.buf.WriteRune('"')
 				}
 				if alt.Characteristics != "" {
 					p.buf.WriteString(",CHARACTERISTICS=\"")


### PR DESCRIPTION
As per the [HLS spec](https://www.rfc-editor.org/rfc/rfc8216), the forced attribute should be either FORCED=YES or FORCED=NO.

This fixes the writer so the value is written unquoted (just like for example AUTOSELECT).